### PR TITLE
Update vaccine gap plot

### DIFF
--- a/global.R
+++ b/global.R
@@ -19,6 +19,7 @@ library(zoo)
 library(sf)
 library(rvest)
 library(RJSONIO)
+library(mgcv)
 
 ## data visualization
 library(ggplot2)

--- a/server.R
+++ b/server.R
@@ -1666,13 +1666,17 @@ server <- function(input, output, session) {
     
     ### calculate smoothed vaccine distribution
     cumulative_dvaccine_min <- dat %>% filter(cumulative_dvaccine != 0) %>% pull(cumulative_dvaccine) %>% min
+    cumulative_dvaccine_max <- dat %>% filter(cumulative_dvaccine != 0) %>% pull(cumulative_dvaccine) %>% max
     dat <- dat %>%
       mutate(
         cumulative_dvaccine_smooth = gam(cumulative_dvaccine ~ s(as.integer(date_vaccine), bs = "tp")) %>%
           fitted %>% round(0),
         cumulative_dvaccine_smooth = ifelse(cumulative_dvaccine_smooth < cumulative_dvaccine_min,
                                             cumulative_dvaccine_min,
-                                            cumulative_dvaccine_smooth) # avoid negative values
+                                            cumulative_dvaccine_smooth), # avoid negative values
+        cumulative_dvaccine_smooth = ifelse(cumulative_dvaccine_smooth > cumulative_dvaccine_max,
+                                            cumulative_dvaccine_max,
+                                            cumulative_dvaccine_smooth) # avoid smoothed values larger than true max value
         )
     
     ### calculate 7-day average vaccine administration

--- a/tabs/tab_vaccines.R
+++ b/tabs/tab_vaccines.R
@@ -61,7 +61,6 @@ tab_vaccines <- tabItem(tabName = "tab_vaccines",
                                      ),
                             )
                           ),
-                          HTML("Note that it is possible for doses administered to temporarily exceed doses distributed for two reasons: 1) Doses distributed is updated less frequently than doses administered and 2) <a href='https://www.saskatchewan.ca/government/news-and-media/2021/february/02/covid19-update-for-february-2-35575-vaccines-delivered-223-new-cases-266-recoveries-eight-deaths' target='_blank'>extra doses can sometimes be obtained beyond the labelled amount</a>."),
                           tabsetPanel(
                             type = "tabs",
                             tabPanel("Vaccine gap",
@@ -81,6 +80,8 @@ tab_vaccines <- tabItem(tabName = "tab_vaccines",
                                      )
                             )
                           ),
+                          HTML("Note that it is possible for doses administered to temporarily exceed doses distributed for two reasons: 1) Doses distributed is updated less frequently than doses administered and 2) <a href='https://www.saskatchewan.ca/government/news-and-media/2021/february/02/covid19-update-for-february-2-35575-vaccines-delivered-223-new-cases-266-recoveries-eight-deaths' target='_blank'>extra doses can sometimes be obtained beyond the labelled amount</a>.<br><br>By default, the vaccine gap plot shows smoothed values of the vaccine distribution time series to account for reporting delays in the distribution numbes. This can be disabled by clicking the \"Smoothed distributed\" button.<br>"),
+                          HTML("<br>"), # blank line
                           tabsetPanel(
                             type = "tabs",
                             tabPanel(


### PR DESCRIPTION
Add 7-day projection of vaccine doses administered (based on average of past 7 days) to contextualize the "vaccine gap" (#3).

![Screenshot from 2021-04-17 15-03-33](https://user-images.githubusercontent.com/31170087/115124114-8924e100-9f8e-11eb-84df-2dfcad4ab18d.png)
